### PR TITLE
Send the channel ID when subscribing to SPEAKING_START, SPEAKING_STOP, and VOICE_STATE_UPDATE event.

### DIFF
--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -169,11 +169,38 @@ func _gen_nonce():
 func subscribe_to_events():
 	if subscribed: return
 	for event in _events:
-		sendMessage(1, {
-			"cmd": "SUBSCRIBE",
-			"evt": event,
-			"nonce": _gen_nonce()
-		})
+		if (event != "SPEAKING_START" || 
+			event != "SPEAKING_STOP" || 
+			event != "VOICE_STATE_UPDATE"):
+			sendMessage(1, {
+				"cmd": "SUBSCRIBE",
+				"evt": event,
+				"nonce": _gen_nonce()
+			})
+	sendMessage(1, {
+		"cmd": "SUBSCRIBE",
+		"evt": "SPEAKING_START",
+		"args": {
+			"channel_id": channel_id
+		},
+		"nonce": _gen_nonce()
+	});
+	sendMessage(1, {
+		"cmd": "SUBSCRIBE",
+		"evt": "SPEAKING_STOP",
+		"args": {
+			"channel_id": channel_id
+		},
+		"nonce": _gen_nonce()
+	});
+	sendMessage(1, {
+		"cmd": "SUBSCRIBE",
+		"evt": "VOICE_STATE_UPDATE",
+		"args": {
+			"channel_id": channel_id
+		},
+		"nonce": _gen_nonce()
+	});
 	subscribed = true
 
 func handshake():


### PR DESCRIPTION
Without the channel ID when subscribing, the events will never get sent to the Godot client even though we dont get an error from Discord. 
We can just manually subscribe to these events outside of the loop where we subscribe to all events. Its only three events we need to do this for so I think this simple solution is fine.