### PR TITLE
Update to match the features of version 1.9.0 of discord/embedded-app-sdk

### DIFF
--- a/playground/playground.gd
+++ b/playground/playground.gd
@@ -108,8 +108,11 @@ func _on_encourage_hw_accel_pressed() -> void:
 func _on_external_url_button_pressed() -> void:
 	var url = $"%ExternalUrlInput".text
 	msg("[i]discord.command_open_external_link(" + str(url) + ")[/i]")
-	var _result = await discord.command_open_external_link(url)
-	msg("[i][b]no output[/b][/i]")
+	var result = await discord.command_open_external_link(url)
+	if (result["opened"]):
+		msg("URL opened")
+	else:
+		msg("URL did not open")
 
 
 func _on_set_orientation_lock_button_pressed() -> void:
@@ -238,6 +241,15 @@ func _on_set_activity_button_pressed() -> void:
 	if (len(secret_spectate) > 0):
 		secrets["spectate"] = secret_spectate
 	discord.command_set_activity(state, details, timestamps, assets, party, secrets, instance)
+
+
+func _on_share_link_button_pressed() -> void:
+	msg("[i]discord.command_share_link()[/i]")
+	var result = await discord.command_share_link("Try out this sick activiy!", discord.user_id, "this is a cool custom id :)")
+	if (result["success"]):
+		msg("Message sent successfully!")
+	else:
+		msg("User cancelled the prompt :( this is a sad day")
 
 
 func _on_oauth_authorize_button_pressed() -> void:

--- a/playground/playground.tscn
+++ b/playground/playground.tscn
@@ -92,7 +92,7 @@ size_flags_horizontal = 3
 [node name="TabContainer" type="TabContainer" parent="HBoxContainer/VSplitContainer"]
 custom_minimum_size = Vector2(0, 300)
 layout_mode = 2
-current_tab = 1
+current_tab = 2
 
 [node name="General" type="VBoxContainer" parent="HBoxContainer/VSplitContainer/TabContainer"]
 visible = false
@@ -237,6 +237,7 @@ layout_mode = 2
 text = "Set Orientation Lock State"
 
 [node name="Info" type="VBoxContainer" parent="HBoxContainer/VSplitContainer/TabContainer"]
+visible = false
 layout_mode = 2
 metadata/_tab_index = 1
 
@@ -257,7 +258,6 @@ layout_mode = 2
 text = "Log User Locale"
 
 [node name="Uploading - Sharing" type="VBoxContainer" parent="HBoxContainer/VSplitContainer/TabContainer"]
-visible = false
 layout_mode = 2
 metadata/_tab_index = 2
 
@@ -288,6 +288,11 @@ text = "Upload Image"
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Share Moment"
+
+[node name="ShareActivityLink" type="Button" parent="HBoxContainer/VSplitContainer/TabContainer/Uploading - Sharing/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Share Activity Link"
 
 [node name="Activity" type="VBoxContainer" parent="HBoxContainer/VSplitContainer/TabContainer"]
 visible = false
@@ -543,6 +548,7 @@ step = 1.0
 [connection signal="pressed" from="HBoxContainer/VSplitContainer/TabContainer/Info/LogUserLocaleButton" to="." method="_on_log_user_locale_button_pressed"]
 [connection signal="pressed" from="HBoxContainer/VSplitContainer/TabContainer/Uploading - Sharing/HBoxContainer/InitiateImageUploadButton" to="." method="_on_initiate_image_upload_button_pressed"]
 [connection signal="pressed" from="HBoxContainer/VSplitContainer/TabContainer/Uploading - Sharing/HBoxContainer/ShareMomentButton" to="." method="_on_share_moment_button_pressed"]
+[connection signal="pressed" from="HBoxContainer/VSplitContainer/TabContainer/Uploading - Sharing/HBoxContainer/ShareActivityLink" to="." method="_on_share_link_button_pressed"]
 [connection signal="pressed" from="HBoxContainer/VSplitContainer/TabContainer/Activity/SetActivityButton" to="." method="_on_set_activity_button_pressed"]
 [connection signal="pressed" from="PipOverlay/VBoxContainer/PipInteractivityTestButton" to="." method="_on_pip_interactivity_test_button_pressed"]
 [connection signal="pressed" from="OauthWindowBg/OauthWindow/VBoxContainer/OauthAuthorizeButton" to="." method="_on_oauth_authorize_button_pressed"]

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -26,6 +26,8 @@ var channel_id : String
 var client_id : String
 var guild_id : String
 var user_id : String
+var custom_id : String
+var referrer_id : String
 
 var source : JavaScriptObject
 var source_origin : String
@@ -117,9 +119,16 @@ func init(client_id_: String):
 	instance_id = query_map["instance_id"]
 	platform = query_map["platform"]
 	channel_id = query_map["channel_id"]
-	guild_id = query_map["guild_id"]
+	if (query_map.has("guild_id")):
+		guild_id = query_map["guild_id"]
+	else:
+		guild_id = ""
+		print("Not in a guild")
+	if (query_map.has("custom_id")):
+		custom_id = query_map["custom_id"]
+	if (query_map.has("referrer_id")):
+		referrer_id = query_map["referrer_id"]
 	client_id = client_id_
-	
 	source = JavaScriptBridge.get_interface("window").parent.opener
 	if (source == null):
 		source = JavaScriptBridge.get_interface("window").parent
@@ -406,6 +415,18 @@ func command_start_purchase(sku_id: String, pid: int):
 func command_user_settings_get_locale():
 	var nonce = _gen_nonce()
 	sendCommand("USER_SETTINGS_GET_LOCALE", {}, nonce)
+	
+	var packet = await _wait_for_nonce(nonce)
+	return packet
+
+
+func command_share_link(message: String, referrer_id: String, custom_id: String):
+	var nonce = _gen_nonce()
+	sendCommand("SHARE_LINK", {
+		"referrer_id": referrer_id,
+		"custom_id": custom_id,
+		"message": message
+	}, nonce)
 	
 	var packet = await _wait_for_nonce(nonce)
 	return packet


### PR DESCRIPTION
# Changes

- Added the SHARE_LINK command
  - Lets you open a modal that lets you share the activity URL with other users
  - Also accepts a "referrer id" and "custom id", these aren't documented so i have NO idea what they're used for
  - custom id is a string, but i only tested with the current user id for referrer, more testing might be required
- Add the `custom_id` and `referrer_id` fields to DiscordSDK
- Make sure that the playground returns the result of OPEN_EXTERNAL_LINK
  - Added in upstream version 1.7.1 but i kept procrastinating this
- Make sure that the entire library doesn't shit its pants if the activity gets started in groups/DM channels