### PR TITLE
Add static typing, and enforce GDScript style guide

### DIFF
--- a/playground/current_user.gd
+++ b/playground/current_user.gd
@@ -11,8 +11,8 @@ func _ready() -> void:
 
 
 func update(data: DiscordSDK.CurrentUserUpdateData) -> void:
-	username.text = data["global_name"] + "  [i](@" + data["username"] + ")[/i]"
-	flags.text = data["id"]
+	username.text = data.global_name + "  [i](@" + data.username + ")[/i]"
+	flags.text = data.id
 	
 	var http_request := HTTPRequest.new()
 	add_child(http_request)

--- a/playground/current_user.gd
+++ b/playground/current_user.gd
@@ -1,30 +1,30 @@
 extends Panel
 
-@onready var discord : DiscordSDK = get_node("/root/Discord")
+@onready var discord: DiscordSDK = get_node("/root/Discord")
 @onready var avatar: TextureRect = $Avatar
 @onready var username: RichTextLabel = $Name
 @onready var flags: RichTextLabel = $Flags
 
 
 func _ready() -> void:
-	discord.connect("dispatch_current_user_update", Callable(self, "update"))
+	discord.dispatch_current_user_update.connect(update)
 
 
-func update(data) -> void:
+func update(data: DiscordSDK.CurrentUserUpdateData) -> void:
 	username.text = data["global_name"] + "  [i](@" + data["username"] + ")[/i]"
 	flags.text = data["id"]
 	
-	var http_request = HTTPRequest.new()
+	var http_request := HTTPRequest.new()
 	add_child(http_request)
-	var _http_error = http_request.request("https://cdn.discordapp.com/avatars/"+data["id"]+"/"+data["avatar"]+".png?size=64")
+	var _http_error := http_request.request("https://cdn.discordapp.com/avatars/%s/%s.png?size=64" % [data.id, data.avatar])
 	var response = await http_request.request_completed
 	print("loaded image?")
 	print(response[1])
 	
-	var image = Image.new()
-	var image_error = image.load_png_from_buffer(response[3])
+	var image := Image.new()
+	var image_error := image.load_png_from_buffer(response[3])
 	print("image load status: " + str(image_error))
 	if image_error != OK:
 		print("An error occurred while trying to display the image.")
-	var texture = ImageTexture.create_from_image(image)
+	var texture := ImageTexture.create_from_image(image)
 	avatar.texture = texture

--- a/playground/current_user.gd.uid
+++ b/playground/current_user.gd.uid
@@ -1,0 +1,1 @@
+uid://bj8mpjo3wq31u

--- a/playground/participant.gd
+++ b/playground/participant.gd
@@ -1,34 +1,34 @@
 class_name Participant
-
 extends Panel
 
 @onready var avatar: TextureRect = $Avatar
 @onready var username: RichTextLabel = $Name
 @onready var flags: RichTextLabel = $Flags
 
-func update(data: Dictionary) -> void:
-	username.text = data["global_name"] + "  [i](@" + data["username"] + ")[/i]"
+
+func update(data: DiscordSDK.DiscordUser) -> void:
+	username.text = data.global_name + "  [i](@" + data.username + ")[/i]"
 	flags.text = ""
 
-	var http_request = HTTPRequest.new()
+	var http_request := HTTPRequest.new()
 	add_child(http_request)
-	var _http_error = http_request.request("https://cdn.discordapp.com/avatars/"+data["id"]+"/"+data["avatar"]+".png?size=64")
+	var _http_error := http_request.request("https://cdn.discordapp.com/avatars/%s/%s.png?size=64" % [data.id, data.avatar])
 	var response = await http_request.request_completed
 	print("loaded image?")
 	print(response[1])
 	
-	var image = Image.new()
-	var image_error = image.load_png_from_buffer(response[3])
+	var image := Image.new()
+	var image_error := image.load_png_from_buffer(response[3])
 	print("image load status: " + str(image_error))
 	if image_error != OK:
 		print("An error occurred while trying to display the image.")
-	var texture = ImageTexture.create_from_image(image)
+	var texture := ImageTexture.create_from_image(image)
 	avatar.texture = texture
 
 
-func voice_state_update(data: Dictionary) -> void:
-	var text = ""
-	var voice_state = data["voice_state"]
+func voice_state_update(data: DiscordSDK.VoiceStateUpdateData) -> void:
+	var text := ""
+	var voice_state := data.voice_state
 	if (voice_state["mute"] == true):
 		text += "M "
 	if (voice_state["deaf"] == true):

--- a/playground/participant.gd.uid
+++ b/playground/participant.gd.uid
@@ -1,0 +1,1 @@
+uid://cnxtlu1ogdm34

--- a/playground/participant.tscn
+++ b/playground/participant.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://cpe1pf8kvomjg"]
 
-[ext_resource type="Script" path="res://playground/participant.gd" id="1_5j4nq"]
+[ext_resource type="Script" uid="uid://cnxtlu1ogdm34" path="res://playground/participant.gd" id="1_5j4nq"]
 [ext_resource type="Texture2D" uid="uid://bw1ygjn8mbgck" path="res://icon.png" id="1_onoq3"]
 
 [node name="User" type="Panel"]

--- a/playground/participants_container.gd
+++ b/playground/participants_container.gd
@@ -1,24 +1,24 @@
 extends VBoxContainer
 
-@onready var discord : DiscordSDK = get_node("/root/Discord")
-var scene = preload("res://playground/participant.tscn")
-var user_nodes : Dictionary = {}
+@onready var discord: DiscordSDK = get_node("/root/Discord")
+var scene := preload("res://playground/participant.tscn")
+var user_nodes: Dictionary[String, Participant] = {}
+
 
 func _ready() -> void:
-	discord.connect("dispatch_activity_instance_participants_update", Callable(self, "update"))
-	discord.connect("dispatch_voice_state_update", Callable(self, "voice_state_update"))
+	discord.dispatch_activity_instance_participants_update.connect(update)
+	discord.dispatch_voice_state_update.connect(voice_state_update)
 
 
-func update(data: Dictionary) -> void:
-	for participant in data["participants"]:
-		if (!user_nodes.has(participant["id"])):
-			var node = scene.instantiate()
+func update(data: DiscordSDK.ParticipantsUpdateData) -> void:
+	for participant in data.participants:
+		if (!user_nodes.has(participant.id)):
+			var node := scene.instantiate()
 			add_child(node)
-			user_nodes[participant["id"]] = node as Participant
-		
-		user_nodes[participant["id"]].update(participant)
+			user_nodes[participant.id] = node as Participant
+		user_nodes[participant.id].update(participant)
 
 
-func voice_state_update(data: Dictionary) -> void:
-	if (user_nodes.has(data["user"]["id"])):
-		user_nodes[data["user"]["id"]].voice_state_update(data)
+func voice_state_update(data: DiscordSDK.VoiceStateUpdateData) -> void:
+	if (user_nodes.has(data.user.id)):
+		user_nodes[data.user.id].voice_state_update(data)

--- a/playground/participants_container.gd.uid
+++ b/playground/participants_container.gd.uid
@@ -1,0 +1,1 @@
+uid://jhba77p51u6f

--- a/playground/playground.gd
+++ b/playground/playground.gd
@@ -1,6 +1,6 @@
 extends Control
 
-const CLIENT_ID = "1219337474266894397"
+const CLIENT_ID := "1219337474266894397"
 
 @onready var discord: DiscordSDK = get_node("/root/Discord")
 @onready var log_node: RichTextLabel = $"HBoxContainer/VSplitContainer/Log"
@@ -27,32 +27,39 @@ func msg_dispatch(event: String, message: String) -> void:
 	dispatch_log_node.text += "\n\n" + event + "\n" + message
 
 
-func _dispatch(event, data) -> void:
+func _dispatch(event: String, data_raw: Object) -> void:
 	raw_dispatch_log_node.text += "\n[ " + event + " ]\n"
-	raw_dispatch_log_node.text += str(data)
+	raw_dispatch_log_node.text += str(data_raw)
 	raw_dispatch_log_node.text += "\n======================================"
 	
 	match event:
 		"READY":
-			msg_dispatch(event, "Dispatch is ready!\nVersion: %s\nCDN Host: %s\nAPI Endpoint: %s\nEnvironment: %s" % [data["v"], data["config"]["cdn_host"], data["config"]["api_endpoint"], data["config"]["environment"]])
+			var data := data_raw as DiscordSDK.ReadyEventData
+			msg_dispatch(event, "Dispatch is ready!\nVersion: %s\nCDN Host: %s\nAPI Endpoint: %s\nEnvironment: %s" % [data.v, data.config.cdn_host, data.config.api_endpoint, data.config.environment])
 		"VOICE_STATE_UPDATE":
-			msg_dispatch(event, "%s's voice state changed!\nMuted: %s\nVolume: %s\nPan: %s - %s" % [data["nick"], str(data["mute"]), str(data["volume"]), str(data["pan"]["left"]), str(data["pan"]["right"])])
+			var data := data_raw as DiscordSDK.VoiceStateUpdateData
+			msg_dispatch(event, "%s's voice state changed!\nMuted: %s\nVolume: %s\nPan: %s - %s" % [data.nick, str(data.mute), str(data.volume), str(data.pan.left), str(data.pan.right)])
 		"SPEAKING_START":
-			msg_dispatch(event, "User with ID %s started speaking" % [data["user_id"]])
+			var data := data_raw as DiscordSDK.SpeakingEventData
+			msg_dispatch(event, "User with ID %s started speaking" % [data.user_id])
 		"SPEAKING_STOP":
-			msg_dispatch(event, "User with ID %s stopped speaking" % [data["user_id"]])
+			var data := data_raw as DiscordSDK.SpeakingEventData
+			msg_dispatch(event, "User with ID %s stopped speaking" % [data.user_id])
 		"ACTIVITY_LAYOUT_MODE_UPDATE":
-			if (data["layout_mode"] == 1):
+			var data := data_raw as DiscordSDK.ActivityLayoutModeUpdateData
+			if data.layout_mode == 1:
 				msg_dispatch(event, "Activity is now in PiP mode")
 			else:
 				msg_dispatch(event, "Activity is no longer in PiP mode")
 		"ORIENTATION_UPDATE":
-			msg_dispatch(event, "Orientation is now %s" % ["landscape" if data["screen_orientation"] == 1 else "portrait"])
+			var data := data_raw as DiscordSDK.OrientationUpdateData
+			msg_dispatch(event, "Orientation is now %s" % ["landscape" if data.screen_orientation == 1 else "portrait"])
 		"CURRENT_USER_UPDATE":
 			msg_dispatch(event, "Current user updated")
 		"THERMAL_STATE_UPDATE":
+			var data := data_raw as DiscordSDK.ThermalStateUpdateData
 			var states = ["normal", "fair", "serious", "critical"]
-			msg_dispatch(event, "Thermal state is now %s" % [states[data["thermal_state"]]])
+			msg_dispatch(event, "Thermal state is now %s" % [states[data.thermal_state]])
 		"ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE":
 			msg_dispatch(event, "Participants updated")
 		"ENTITLEMENT_CREATE":
@@ -63,8 +70,8 @@ func _dispatch(event, data) -> void:
 			msg_dispatch(event, "Unknown event")
 
 
-func _pip_change(data) -> void:
-	if (data["layout_mode"] == 1):
+func _pip_change(data: DiscordSDK.ActivityLayoutModeUpdateData) -> void:
+	if data.layout_mode == 1:
 		$"%PipOverlay".visible = true
 	else:
 		$"%PipOverlay".visible = false
@@ -72,8 +79,8 @@ func _pip_change(data) -> void:
 
 func _on_set_config_button_pressed() -> void:
 	var config: bool = $"%PipInteractivityState".get_selected_id() == 1
-	msg("[i]discord.command_set_config(" + str(config) + ")[/i]")
-	var _result = await discord.command_set_config(config)
+	msg("[i]discord.command_set_config(%s)[/i]" % str(config))
+	var _result := await discord.command_set_config(config)
 	msg("[i][b]no output[/b][/i]")
 
 
@@ -91,8 +98,8 @@ func _on_capture_log_button_pressed() -> void:
 			level = "info"
 		4:
 			level = "error"
-	var message = $"%LogMessage".text
-	msg("[i]discord.command_capture_log(\"" + level + "\", \"" + message + "\")[/i]")
+	var message: String = $"%LogMessage".text
+	msg("[i]discord.command_capture_log(%s, %s)[/i]" % [level, message])
 	var _result := await discord.command_capture_log(level, message)
 	msg("[i][b]no output[/b][/i]")
 
@@ -105,9 +112,9 @@ func _on_encourage_hw_accel_pressed() -> void:
 
 func _on_external_url_button_pressed() -> void:
 	var url: String = $"%ExternalUrlInput".text
-	msg("[i]discord.command_open_external_link(" + str(url) + ")[/i]")
+	msg("[i]discord.command_open_external_link(%s)[/i]" % str(url))
 	var result := await discord.command_open_external_link(url)
-	if (result["opened"]):
+	if result.opened:
 		msg("URL opened")
 	else:
 		msg("URL did not open")
@@ -118,31 +125,31 @@ func _on_set_orientation_lock_button_pressed() -> void:
 	var pip_lock_state: int = -1 if $"%PipLockState".get_selected_id() == 0 else $"%PipLockState".get_selected_id()
 	var grid_lock_state: int = -1 if $"%GridLockState".get_selected_id() == 0 else $"%GridLockState".get_selected_id()
 
-	msg("[i]discord.command_set_orientation_lock_state(" + str(lock_state) + ", " + str(pip_lock_state) + ", " + str(grid_lock_state) + ")[/i]")
+	msg("[i]discord.command_set_orientation_lock_state(%s, %s, %s)[/i]" % [lock_state, pip_lock_state, grid_lock_state])
 	var _result := await discord.command_set_orientation_lock_state(lock_state, pip_lock_state, grid_lock_state)
 	msg("[i][b]no output[/b][/i]")
 
 
 func _on_log_channel_info_button_pressed() -> void:
-	msg("[i]discord.command_get_channel(" + str(discord.channel_id) + ")[/i]")
+	msg("[i]discord.command_get_channel(%s)[/i]" % str(discord.channel_id))
 	var result := await discord.command_get_channel(discord.channel_id)
 	msg("[Channel Info] =====================================================")
-	msg("Id: " + str(result["id"]))
-	msg("Name: " + str(result["name"]))
-	msg("Type: " + str(result["type"]))
-	msg("Topic: " + str(result["topic"]))
-	msg("Bitrate: " + str(result["bitrate"]))
-	msg("User Limit: " + str(result["user_limit"]))
-	msg("Guild Id: " + str(result["guild_id"]))
-	msg("Position: " + str(result["position"]))
+	msg("Id: " + str(result.id))
+	msg("Name: " + str(result.name))
+	msg("Type: " + str(result.type))
+	msg("Topic: " + str(result.topic))
+	msg("Bitrate: " + str(result.bitrate))
+	msg("User Limit: " + str(result.user_limit))
+	msg("Guild Id: " + str(result.guild_id))
+	msg("Position: " + str(result.position))
 	msg("[Voice States]")
-	for state in result["voice_states"]:
-		msg("- Nick: " + str(state["nick"]))
-		msg("  Muted: " + str(state["mute"]))
-		msg("  Volume: " + str(state["volume"]))
+	for state in result.voice_states:
+		msg("- Nick: " + str(state.nick))
+		msg("  Muted: " + str(state.mute))
+		msg("  Volume: " + str(state.volume))
 		msg("  Pan:")
-		msg("    Left: " + str(state["pan"]["left"]))
-		msg("    Right: " + str(state["pan"]["right"]))
+		msg("    Left: " + str(state.pan.left))
+		msg("    Right: " + str(state.pan.right))
 	msg("[/Voice States]")
 	msg("[/Channel Info] ====================================================")
 
@@ -151,7 +158,7 @@ func _on_log_channel_permissions_button_pressed() -> void:
 	msg("[i]discord.command_get_channel_permissions()[/i]")
 	var result := await discord.command_get_channel_permissions()
 	msg("[Channel Permissions] ==============================================")
-	msg("Permissions: " + str(result["permissions"]))
+	msg("Permissions: " + str(result.permissions))
 	msg("[/Channel Permissions] =============================================")
 
 
@@ -167,15 +174,15 @@ func _on_log_platform_behaviors_button_pressed() -> void:
 func _on_log_user_locale_button_pressed() -> void:
 	msg("[i]discord.command_user_settings_get_locale()[/i]")
 	var result := await discord.command_user_settings_get_locale()
-	msg("[b]User Locale: [/b] " + result["locale"])
+	msg("[b]User Locale: [/b] " + result.locale)
 
 
 func _on_initiate_image_upload_button_pressed() -> void:
 	var line_edit: LineEdit = $"%ShareMomentUrl"
 	msg("[i]discord.command_initiate_image_upload()[/i]")
 	var result := await discord.command_initiate_image_upload()
-	msg("Image URL: " + str(result["image_url"]))
-	line_edit.text = str(result["image_url"])
+	msg("Image URL: " + str(result.image_url))
+	line_edit.text = str(result.image_url)
 
 
 func _on_share_moment_button_pressed() -> void:
@@ -213,30 +220,30 @@ func _on_set_activity_button_pressed() -> void:
 	var party := {}
 	var secrets := {}
 
-	if (len(start_date) > 0):
+	if len(start_date) > 0:
 		timestamps["start"] = int(start_date)
-	if (len(end_date) > 0):
+	if len(end_date) > 0:
 		timestamps["end"] = int(end_date)
-	if (len(small_image) > 0):
+	if len(small_image) > 0:
 		assets["small_image"] = str(small_image)
-	if (len(small_image_text) > 0):
+	if len(small_image_text) > 0:
 		assets["small_text"] = str(small_image_text)
-	if (len(large_image) > 0):
+	if len(large_image) > 0:
 		assets["large_image"] = str(large_image)
-	if (len(large_image_text) > 0):
+	if len(large_image_text) > 0:
 		assets["large_text"] = str(large_image_text)
-	if (len(party_id) > 0):
+	if len(party_id) > 0:
 		party["id"] = party_id
-	if (len(party_member_count) > 0 or len(party_member_max) > 0):
+	if len(party_member_count) > 0 or len(party_member_max) > 0:
 		party["size"] = [
 			int(party_member_count),
 			int(party_member_max)
 		]
-	if (len(secret_match) > 0):
+	if len(secret_match) > 0:
 		secrets["match"] = secret_match
-	if (len(secret_join) > 0):
+	if len(secret_join) > 0:
 		secrets["join"] = secret_join
-	if (len(secret_spectate) > 0):
+	if len(secret_spectate) > 0:
 		secrets["spectate"] = secret_spectate
 	discord.command_set_activity(state, details, timestamps, assets, party, secrets, instance)
 
@@ -244,7 +251,7 @@ func _on_set_activity_button_pressed() -> void:
 func _on_share_link_button_pressed() -> void:
 	msg("[i]discord.command_share_link()[/i]")
 	var result := await discord.command_share_link("Try out this sick activiy!", discord.user_id, "this is a cool custom id :)")
-	if (result["success"]):
+	if result.success:
 		msg("Message sent successfully!")
 	else:
 		msg("User cancelled the prompt :( this is a sad day")
@@ -254,15 +261,15 @@ func _on_oauth_authorize_button_pressed() -> void:
 	var scopes := []
 	var progress: ProgressBar = $"%OauthProgressBar"
 	
-	if ($"%OauthScopeIdentify".button_pressed):
+	if $"%OauthScopeIdentify".button_pressed:
 		scopes.append("identify")
-	if ($"%OauthScopeGuilds".button_pressed):
+	if $"%OauthScopeGuilds".button_pressed:
 		scopes.append("guilds")
-	if ($"%OauthScopeActivitiesWrite".button_pressed):
+	if $"%OauthScopeActivitiesWrite".button_pressed:
 		scopes.append("rpc.activities.write")
-	if ($"%OauthScopeVoiceRead".button_pressed):
+	if $"%OauthScopeVoiceRead".button_pressed:
 		scopes.append("rpc.voice.read")
-	if ($"%OauthScopeMembersRead".button_pressed):
+	if $"%OauthScopeMembersRead".button_pressed:
 		scopes.append("guilds.members.read")
 	
 	progress.value = 1
@@ -273,14 +280,14 @@ func _on_oauth_authorize_button_pressed() -> void:
 	hreq.accept_gzip = false # ?? huh? https://forum.godotengine.org/t/-/37681/19
 	add_child(hreq)
 	var _token_res := hreq.request(
-		"https://" + CLIENT_ID + ".discordsays.com/.proxy/api/auth",
+		"https://%s.discordsays.com/.proxy/api/auth" % CLIENT_ID,
 		["Content-Type: application/x-www-form-urlencoded"],
 		HTTPClient.METHOD_POST,
 		"code=" + auth["code"]
 	)
 	var response = await hreq.request_completed
 	hreq.queue_free()
-	var json = response[3].get_string_from_utf8()
+	var json: String = response[3].get_string_from_utf8()
 	var token_json: Dictionary = JSON.parse_string(json)
 	var token: String = token_json["access_token"]
 	progress.value = 3

--- a/playground/playground.gd
+++ b/playground/playground.gd
@@ -2,21 +2,19 @@ extends Control
 
 const CLIENT_ID = "1219337474266894397"
 
-@onready var discord : DiscordSDK = get_node("/root/Discord")
-@onready var log_node : RichTextLabel = $"HBoxContainer/VSplitContainer/Log"
-@onready var dispatch_log_node : RichTextLabel = $"%Dispatch"
-@onready var raw_dispatch_log_node : RichTextLabel = $"%Raw Dispatch"
+@onready var discord: DiscordSDK = get_node("/root/Discord")
+@onready var log_node: RichTextLabel = $"HBoxContainer/VSplitContainer/Log"
+@onready var dispatch_log_node: RichTextLabel = $"%Dispatch"
+@onready var raw_dispatch_log_node: RichTextLabel = $"%Raw Dispatch"
 
-var pip_interactivity_press_count = 0
+var pip_interactivity_press_count := 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	discord.init(CLIENT_ID)
 	
-	discord.connect("dispatch_any", Callable(self, "_dispatch"))
-	discord.connect("dispatch_current_user_update", Callable(self, "_user_updated"))
-	
-	discord.connect("dispatch_activity_layout_mode_update", Callable(self, "_pip_change"))
+	discord.dispatch_any.connect(_dispatch)
+	discord.dispatch_activity_layout_mode_update.connect(_pip_change)
 	
 	log_node.set_scroll_follow(true)
 
@@ -73,15 +71,15 @@ func _pip_change(data) -> void:
 
 
 func _on_set_config_button_pressed() -> void:
-	var config = $"%PipInteractivityState".get_selected_id() == 1
+	var config: bool = $"%PipInteractivityState".get_selected_id() == 1
 	msg("[i]discord.command_set_config(" + str(config) + ")[/i]")
 	var _result = await discord.command_set_config(config)
 	msg("[i][b]no output[/b][/i]")
 
 
 func _on_capture_log_button_pressed() -> void:
-	var level_id = $"%LogLevel".get_selected_id()
-	var level = "log"
+	var level_id: int = $"%LogLevel".get_selected_id()
+	var level := "log"
 	match level_id:
 		0:
 			level = "log"
@@ -95,20 +93,20 @@ func _on_capture_log_button_pressed() -> void:
 			level = "error"
 	var message = $"%LogMessage".text
 	msg("[i]discord.command_capture_log(\"" + level + "\", \"" + message + "\")[/i]")
-	var _result = await discord.command_capture_log(level, message)
+	var _result := await discord.command_capture_log(level, message)
 	msg("[i][b]no output[/b][/i]")
 
 
 func _on_encourage_hw_accel_pressed() -> void:
 	msg("[i]discord.command_encourage_hardware_acceleration()[/i]")
-	var result = await discord.command_encourage_hardware_acceleration()
+	var result := await discord.command_encourage_hardware_acceleration()
 	msg("Hardware acceleration is: " + ("Enabled" if result["enabled"] else "Disabled"))
 
 
 func _on_external_url_button_pressed() -> void:
-	var url = $"%ExternalUrlInput".text
+	var url: String = $"%ExternalUrlInput".text
 	msg("[i]discord.command_open_external_link(" + str(url) + ")[/i]")
-	var result = await discord.command_open_external_link(url)
+	var result := await discord.command_open_external_link(url)
 	if (result["opened"]):
 		msg("URL opened")
 	else:
@@ -116,18 +114,18 @@ func _on_external_url_button_pressed() -> void:
 
 
 func _on_set_orientation_lock_button_pressed() -> void:
-	var lock_state = -1 if $"%LockState".get_selected_id() == 0 else $"%LockState".get_selected_id()
-	var pip_lock_state = -1 if $"%PipLockState".get_selected_id() == 0 else $"%PipLockState".get_selected_id()
-	var grid_lock_state = -1 if $"%GridLockState".get_selected_id() == 0 else $"%GridLockState".get_selected_id()
+	var lock_state: int = -1 if $"%LockState".get_selected_id() == 0 else $"%LockState".get_selected_id()
+	var pip_lock_state: int = -1 if $"%PipLockState".get_selected_id() == 0 else $"%PipLockState".get_selected_id()
+	var grid_lock_state: int = -1 if $"%GridLockState".get_selected_id() == 0 else $"%GridLockState".get_selected_id()
 
 	msg("[i]discord.command_set_orientation_lock_state(" + str(lock_state) + ", " + str(pip_lock_state) + ", " + str(grid_lock_state) + ")[/i]")
-	var _result = await discord.command_set_orientation_lock_state(lock_state, pip_lock_state, grid_lock_state)
+	var _result := await discord.command_set_orientation_lock_state(lock_state, pip_lock_state, grid_lock_state)
 	msg("[i][b]no output[/b][/i]")
 
 
 func _on_log_channel_info_button_pressed() -> void:
 	msg("[i]discord.command_get_channel(" + str(discord.channel_id) + ")[/i]")
-	var result = await discord.command_get_channel(discord.channel_id)
+	var result := await discord.command_get_channel(discord.channel_id)
 	msg("[Channel Info] =====================================================")
 	msg("Id: " + str(result["id"]))
 	msg("Name: " + str(result["name"]))
@@ -151,7 +149,7 @@ func _on_log_channel_info_button_pressed() -> void:
 
 func _on_log_channel_permissions_button_pressed() -> void:
 	msg("[i]discord.command_get_channel_permissions()[/i]")
-	var result = await discord.command_get_channel_permissions()
+	var result := await discord.command_get_channel_permissions()
 	msg("[Channel Permissions] ==============================================")
 	msg("Permissions: " + str(result["permissions"]))
 	msg("[/Channel Permissions] =============================================")
@@ -159,7 +157,7 @@ func _on_log_channel_permissions_button_pressed() -> void:
 
 func _on_log_platform_behaviors_button_pressed() -> void:
 	msg("[i]discord.command_get_platform_behaviors()[/i]")
-	var result = await discord.command_get_platform_behaviors()
+	var result := await discord.command_get_platform_behaviors()
 	msg("[Platform Behaviors] ===============================================")
 	for key in result:
 		msg(str(key) + ": " + str(result[key]))
@@ -168,28 +166,28 @@ func _on_log_platform_behaviors_button_pressed() -> void:
 
 func _on_log_user_locale_button_pressed() -> void:
 	msg("[i]discord.command_user_settings_get_locale()[/i]")
-	var result = await discord.command_user_settings_get_locale()
+	var result := await discord.command_user_settings_get_locale()
 	msg("[b]User Locale: [/b] " + result["locale"])
 
 
 func _on_initiate_image_upload_button_pressed() -> void:
-	var line_edit : LineEdit = $"%ShareMomentUrl"
+	var line_edit: LineEdit = $"%ShareMomentUrl"
 	msg("[i]discord.command_initiate_image_upload()[/i]")
-	var result = await discord.command_initiate_image_upload()
+	var result := await discord.command_initiate_image_upload()
 	msg("Image URL: " + str(result["image_url"]))
 	line_edit.text = str(result["image_url"])
 
 
 func _on_share_moment_button_pressed() -> void:
-	var line_edit : LineEdit = $"%ShareMomentUrl"
+	var line_edit: LineEdit = $"%ShareMomentUrl"
 	msg("[i]discord.command_open_share_moment_dialog()[/i]")
-	var _result = await discord.command_open_share_moment_dialog(line_edit.text)
+	var _result := await discord.command_open_share_moment_dialog(line_edit.text)
 	msg("[i][b]no output[/b][/i]")
 
 
 func _on_invite_button_pressed() -> void:
 	msg("[i]discord.command_open_invite_dialog()[/i]")
-	var _result = await discord.command_open_invite_dialog()
+	var _result := await discord.command_open_invite_dialog()
 	msg("[i][b]no output[/b][/i]")
 
 
@@ -210,10 +208,10 @@ func _on_set_activity_button_pressed() -> void:
 	var secret_spectate    = $"%ActivitySpectateSecret".text
 	var instance           = $"%ActivityInstance".button_pressed
 
-	var timestamps = {}
-	var assets = {}
-	var party = {}
-	var secrets = {}
+	var timestamps := {}
+	var assets := {}
+	var party := {}
+	var secrets := {}
 
 	if (len(start_date) > 0):
 		timestamps["start"] = int(start_date)
@@ -245,7 +243,7 @@ func _on_set_activity_button_pressed() -> void:
 
 func _on_share_link_button_pressed() -> void:
 	msg("[i]discord.command_share_link()[/i]")
-	var result = await discord.command_share_link("Try out this sick activiy!", discord.user_id, "this is a cool custom id :)")
+	var result := await discord.command_share_link("Try out this sick activiy!", discord.user_id, "this is a cool custom id :)")
 	if (result["success"]):
 		msg("Message sent successfully!")
 	else:
@@ -253,8 +251,8 @@ func _on_share_link_button_pressed() -> void:
 
 
 func _on_oauth_authorize_button_pressed() -> void:
-	var scopes = []
-	var progress : ProgressBar = $"%OauthProgressBar"
+	var scopes := []
+	var progress: ProgressBar = $"%OauthProgressBar"
 	
 	if ($"%OauthScopeIdentify".button_pressed):
 		scopes.append("identify")
@@ -269,12 +267,12 @@ func _on_oauth_authorize_button_pressed() -> void:
 	
 	progress.value = 1
 	msg("Authorizing with scopes: " + str(scopes))
-	var auth = await discord.command_authorize("code", scopes, "")
+	var auth := await discord.command_authorize("code", scopes, "")
 	progress.value = 2
-	var hreq = HTTPRequest.new()
+	var hreq := HTTPRequest.new()
 	hreq.accept_gzip = false # ?? huh? https://forum.godotengine.org/t/-/37681/19
 	add_child(hreq)
-	var _token_res = hreq.request(
+	var _token_res := hreq.request(
 		"https://" + CLIENT_ID + ".discordsays.com/.proxy/api/auth",
 		["Content-Type: application/x-www-form-urlencoded"],
 		HTTPClient.METHOD_POST,
@@ -283,8 +281,8 @@ func _on_oauth_authorize_button_pressed() -> void:
 	var response = await hreq.request_completed
 	hreq.queue_free()
 	var json = response[3].get_string_from_utf8()
-	var token_json = JSON.parse_string(json)
-	var token = token_json["access_token"]
+	var token_json: Dictionary = JSON.parse_string(json)
+	var token: String = token_json["access_token"]
 	progress.value = 3
 	msg("Got access token")
 	var _authRes = await discord.command_authenticate(token)

--- a/playground/playground.gd
+++ b/playground/playground.gd
@@ -100,7 +100,7 @@ func _on_capture_log_button_pressed() -> void:
 			level = "error"
 	var message: String = $"%LogMessage".text
 	msg("[i]discord.command_capture_log(%s, %s)[/i]" % [level, message])
-	var _result := await discord.command_capture_log(level, message)
+	await discord.command_capture_log(level, message)
 	msg("[i][b]no output[/b][/i]")
 
 
@@ -126,7 +126,7 @@ func _on_set_orientation_lock_button_pressed() -> void:
 	var grid_lock_state: int = -1 if $"%GridLockState".get_selected_id() == 0 else $"%GridLockState".get_selected_id()
 
 	msg("[i]discord.command_set_orientation_lock_state(%s, %s, %s)[/i]" % [lock_state, pip_lock_state, grid_lock_state])
-	var _result := await discord.command_set_orientation_lock_state(lock_state, pip_lock_state, grid_lock_state)
+	await discord.command_set_orientation_lock_state(lock_state, pip_lock_state, grid_lock_state)
 	msg("[i][b]no output[/b][/i]")
 
 
@@ -166,8 +166,8 @@ func _on_log_platform_behaviors_button_pressed() -> void:
 	msg("[i]discord.command_get_platform_behaviors()[/i]")
 	var result := await discord.command_get_platform_behaviors()
 	msg("[Platform Behaviors] ===============================================")
-	for key in result:
-		msg(str(key) + ": " + str(result[key]))
+	if result.ios_keyboard_resizes_view != null:
+		msg("ios_keyboard_resizes_view: " + str(result.ios_keyboard_resizes_view))
 	msg("[/Platform Behaviors] ==============================================")
 
 
@@ -188,13 +188,13 @@ func _on_initiate_image_upload_button_pressed() -> void:
 func _on_share_moment_button_pressed() -> void:
 	var line_edit: LineEdit = $"%ShareMomentUrl"
 	msg("[i]discord.command_open_share_moment_dialog()[/i]")
-	var _result := await discord.command_open_share_moment_dialog(line_edit.text)
+	await discord.command_open_share_moment_dialog(line_edit.text)
 	msg("[i][b]no output[/b][/i]")
 
 
 func _on_invite_button_pressed() -> void:
 	msg("[i]discord.command_open_invite_dialog()[/i]")
-	var _result := await discord.command_open_invite_dialog()
+	await discord.command_open_invite_dialog()
 	msg("[i][b]no output[/b][/i]")
 
 

--- a/playground/playground.gd
+++ b/playground/playground.gd
@@ -100,7 +100,7 @@ func _on_capture_log_button_pressed() -> void:
 func _on_encourage_hw_accel_pressed() -> void:
 	msg("[i]discord.command_encourage_hardware_acceleration()[/i]")
 	var result := await discord.command_encourage_hardware_acceleration()
-	msg("Hardware acceleration is: " + ("Enabled" if result["enabled"] else "Disabled"))
+	msg("Hardware acceleration is: " + ("Enabled" if result.enabled else "Disabled"))
 
 
 func _on_external_url_button_pressed() -> void:

--- a/playground/playground.gd.uid
+++ b/playground/playground.gd.uid
@@ -1,0 +1,1 @@
+uid://s1ukco43qu4p

--- a/playground/playground.tscn
+++ b/playground/playground.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=5 format=3 uid="uid://cpo3ygbiavdgb"]
 
 [ext_resource type="Texture2D" uid="uid://bw1ygjn8mbgck" path="res://icon.png" id="1_3ml1p"]
-[ext_resource type="Script" path="res://playground/playground.gd" id="1_jqnx3"]
-[ext_resource type="Script" path="res://playground/current_user.gd" id="2_m88sq"]
-[ext_resource type="Script" path="res://playground/participants_container.gd" id="2_rr0wr"]
+[ext_resource type="Script" uid="uid://s1ukco43qu4p" path="res://playground/playground.gd" id="1_jqnx3"]
+[ext_resource type="Script" uid="uid://bj8mpjo3wq31u" path="res://playground/current_user.gd" id="2_m88sq"]
+[ext_resource type="Script" uid="uid://jhba77p51u6f" path="res://playground/participants_container.gd" id="2_rr0wr"]
 
 [node name="Playground" type="Control"]
 layout_mode = 3
@@ -113,6 +113,7 @@ selected = 0
 fit_to_longest_item = false
 item_count = 2
 popup/item_0/text = "PiP window is not interactive"
+popup/item_0/id = 0
 popup/item_1/text = "PiP window is interactive"
 popup/item_1/id = 1
 
@@ -132,6 +133,7 @@ layout_mode = 2
 selected = 0
 item_count = 5
 popup/item_0/text = "Log"
+popup/item_0/id = 0
 popup/item_1/text = "Warning"
 popup/item_1/id = 1
 popup/item_2/text = "Debug"
@@ -195,6 +197,7 @@ selected = 0
 fit_to_longest_item = false
 item_count = 4
 popup/item_0/text = "Unhandled"
+popup/item_0/id = 0
 popup/item_1/text = "Unlocked"
 popup/item_1/id = 1
 popup/item_2/text = "Portrait"
@@ -210,6 +213,7 @@ selected = 0
 fit_to_longest_item = false
 item_count = 4
 popup/item_0/text = "Unhandled"
+popup/item_0/id = 0
 popup/item_1/text = "Unlocked"
 popup/item_1/id = 1
 popup/item_2/text = "Portrait"
@@ -225,6 +229,7 @@ selected = 0
 fit_to_longest_item = false
 item_count = 4
 popup/item_0/text = "Unhandled"
+popup/item_0/id = 0
 popup/item_1/text = "Unlocked"
 popup/item_1/id = 1
 popup/item_2/text = "Portrait"

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -158,6 +158,26 @@ class ParticipantsUpdateData:
 
 
 #region Custom SDK types, only used for this SDK
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#uservoicestate
+class DiscordUserVoiceState:
+	var mute: bool
+	var nick: String
+	var user: DiscordUser
+	var voice_state: DiscordVoiceState
+	var volume: int
+	var pan: DiscordAudioPan
+	static func decode(dict: Dictionary) -> DiscordUserVoiceState:
+		var data := DiscordUserVoiceState.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("user") != null:
+			data.user = DiscordUser.decode(dict["user"])
+		if dict.get("voice_state") != null:
+			data.voice_state = DiscordVoiceState.decode(dict["voice_state"])
+		if dict.get("pan") != null:
+			data.pan = DiscordAudioPan.decode(dict["pan"])
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#voicestate
 class DiscordVoiceState:
 	var mute: bool
 	var deaf: bool
@@ -168,6 +188,7 @@ class DiscordVoiceState:
 		var data := DiscordVoiceState.new()
 		DiscordSDK._decode_simple(dict, data)
 		return data
+
 class DiscordAudioPan:
 	var left: float
 	var right: float
@@ -180,6 +201,44 @@ class DiscordAudioPan:
 
 #region SDK interface types (https://discord.com/developers/docs/developer-tools/embedded-app-sdk#sdk-interfaces)
 #       Prefix them with "Discord" in order to not clash with outside types.
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#channeltypesobject
+enum DiscordChannelTypes {
+	UNHANDLED = -1,
+	DM = 1,
+	GROUP_DM = 3,
+	GUILD_TEXT = 0,
+	GUILD_VOICE = 2,
+	GUILD_CATEGORY = 4,
+	GUILD_ANNOUNCEMENT = 5,
+	GUILD_STORE = 6,
+	ANNOUNCEMENT_THREAD = 10,
+	PUBLIC_THREAD = 11,
+	PRIVATE_THREAD = 12,
+	GUILD_STAGE_VOICE = 13,
+	GUILD_DIRECTORY = 14,
+	GUILD_FORUM = 15,
+}
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#orientationlockstatetypeobject
+enum DiscordOrientationLockStateType {
+	UNHANDLED = -1,
+	UNLOCKED = 1,
+	PORTRAIT = 2,
+	LANDSCAPE = 3
+}
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#skutypeobject
+enum DiscordSkuType {
+	UNHANDLED = -1,
+	APPLICATION = 1,
+	DLC = 2,
+	CONSUMABLE = 3,
+	BUNDLE = 4,
+	SUBSCRIPTION = 5
+}
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#activity
 class DiscordActivity:
 	## The name of the activity
 	var name: String
@@ -199,16 +258,32 @@ class DiscordActivity:
 	var state: String
 	## Emoji (Nullable)
 	var emoji: DiscordEmoji
-	
-	static func decode(dict: Dictionary) -> DiscordAudioPan:
-		var data := DiscordAudioPan.new()
+	## Party (Nullable)
+	var party: DiscordParty
+	## Assets (Nullable)
+	var assets: DiscordAssets
+	## Secrets (Nullable)
+	var secrets: DiscordSecrets
+	## Instance (Nullable)
+	var instance: bool
+	## Flags (Nullable)
+	var flags: int
+	static func decode(dict: Dictionary) -> DiscordActivity:
+		var data := DiscordActivity.new()
 		DiscordSDK._decode_simple(dict, data)
 		if dict.get("timestamps") != null:
 			data.timestamps = DiscordTimestamp.decode(dict["timestamps"])
 		if dict.get("emoji") != null:
 			data.emoji = DiscordEmoji.decode(dict["emoji"])
+		if dict.get("party") != null:
+			data.party = DiscordParty.decode(dict["party"])
+		if dict.get("assets") != null:
+			data.assets = DiscordAssets.decode(dict["assets"])
+		if dict.get("secrets") != null:
+			data.secrets = DiscordSecrets.decode(dict["secrets"])
 		return data
 
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#emoji
 class DiscordEmoji:
 	## Emoji ID
 	var id: String
@@ -233,6 +308,7 @@ class DiscordEmoji:
 			data.user = DiscordUser.decode(dict["user"])
 		return data
 
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#timestamp
 class DiscordTimestamp:
 	## Start time (Nullable)
 	var start: int
@@ -243,6 +319,40 @@ class DiscordTimestamp:
 		DiscordSDK._decode_simple(dict, data)
 		return data
 
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#attachment
+class DiscordAttachment:
+	## ID
+	var id: String
+	## Filename
+	var filename: String
+	## Size
+	var size: int
+	## URL
+	var url: String
+	## Proxy URL
+	var proxy_url: String
+	## Height (Nullable)
+	var height:	int
+	## Width (Nullable)
+	var width:	int
+	static func decode(dict: Dictionary) -> DiscordAttachment:
+		var data := DiscordAttachment.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#reaction
+class DiscordReaction:
+	var count: int
+	var me: bool
+	var emoji: DiscordEmoji
+	static func decode(dict: Dictionary) -> DiscordReaction:
+		var data := DiscordReaction.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("emoji") != null:
+			data.emoji = DiscordEmoji.decode(dict["emoji"])
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#user
 class DiscordUser extends DiscordSimpleUser:
 	## Global name (Nullable)
 	var global_name: String
@@ -276,11 +386,465 @@ class DiscordSimpleUser:
 class DiscordAvatarDecorationData:
 	## Asset
 	var asset: String
-	## (Nullable)
+	## SKU ID (Nullable)
 	var sku_id: String
 	static func decode(dict: Dictionary) -> DiscordAvatarDecorationData:
 		var data := DiscordAvatarDecorationData.new()
 		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#guildmember
+class DiscordGuildMember:
+	## User
+	var user: DiscordUser
+	## Nick (Nullable)
+	var nick: String
+	## Roles
+	var roles: Array[String] = []
+	## Joined at
+	var joined_at: String
+	## Deaf
+	var deaf: bool
+	## Mute
+	var mute: bool
+	static func decode(dict: Dictionary) -> DiscordGuildMember:
+		var data := DiscordGuildMember.new()
+		DiscordSDK._decode_simple(dict, data)
+		data.user = DiscordUser.decode(dict["user"])
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#assets
+class DiscordAssets:
+	## Large image (Nullable)
+	var large_image: String
+	## Large text (Nullable)
+	var large_text: String
+	## Small image (Nullable)
+	var small_image: String
+	## Small text (Nullable)
+	var small_text: String
+	static func decode(dict: Dictionary) -> DiscordAssets:
+		var data := DiscordAssets.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#application
+class DiscordApplication:
+	## Description
+	var description: String
+	## Icon (Nullable)
+	var icon: String
+	## Id
+	var id: String
+	## RPC origins
+	var rpc_origins: Array[String] = []
+	## Name
+	var name: String
+	static func decode(dict: Dictionary) -> DiscordApplication:
+		var data := DiscordApplication.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#party
+class DiscordParty:
+	## Party ID (Nullable)
+	var id: String
+	## Party size (Nullable)
+	var size: Array[String]
+	static func decode(dict: Dictionary) -> DiscordParty:
+		var data := DiscordParty.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#relationship
+class DiscordRelationship:
+	## Relationship type
+	var type: int
+	## Relationship user
+	var user: DiscordUser
+	static func decode(dict: Dictionary) -> DiscordApplication:
+		var data := DiscordApplication.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("user") != null:
+			data.user = DiscordUser.decode(data["user"])
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#secrets
+class DiscordSecrets:
+	## Join secret (Nullable)
+	var id_secret: String
+	## Match secret (Nullable)
+	var match_secret: String
+	static func decode(dict: Dictionary) -> DiscordSecrets:
+		var data := DiscordSecrets.new()
+		data.id_secret = dict["secret"]
+		data.match_secret = dict["match"]
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#message
+class DiscordMessage:
+	## ID
+	var id: String
+	## Channel ID
+	var channel_id: String
+	## Guild ID (Nullable)
+	var guild_id
+	## Author (Nullable)
+	var author: DiscordUser
+	## Member (Nullable)
+	var member: DiscordGuildMember
+	## Content
+	var content: String
+	## Timestamp
+	var timestamp: String
+	## Edited timestamp (Nullable)
+	var edited_timestamp: String
+	## Text-to-speech
+	var tts: bool
+	## Mention everyone
+	var mention_everyone: bool
+	## Mentions
+	var mentions: Array[DiscordUser]
+	## Mention roles
+	var mention_roles: Array[String]
+	## Mentioned channels
+	var mention_channels: Array[Dictionary]
+	## Attachments
+	var attachments: Array[DiscordAttachment]
+	## Embeds
+	var embeds: Array[Dictionary]  # TODO: Make a data type for embeds
+	## Reactions (Nullable)
+	var reactions: Array[DiscordReaction]
+	## Nonce
+	var nonce: String
+	## Pinned
+	var pinned: bool
+	## Webhook ID (Nullable)
+	var webhook_id: String
+	## Type
+	var type: int
+	## Message activity (Nullable)
+	var activity: DiscordMessageActivity
+	## Message application (Nullable)
+	var application: DiscordMessageApplication
+	## Message reference (Nullable)
+	var message_reference: DiscordMessageReference
+	## Flags
+	var flags: int
+	## Stickers (Nullable)
+	var stickers: Array[Dictionary]  # Stickers don't seem to have a type in the docs?
+	## Referenced message (Nullable)
+	var referenced_message: DiscordMessage
+	static func decode(dict: Dictionary) -> DiscordMessage:
+		var data := DiscordMessage.new()
+		DiscordSDK._decode_simple(dict, data)
+		data.author = DiscordUser.decode(dict["author"])
+		data.member = DiscordGuildMember.decode(dict["member"])
+		if dict.get("mentions") != null:
+			data.mentions = []
+			for mention in dict["mentions"]:
+				data.mentions.push_back(DiscordUser.decode(mention))
+		if dict.get("attachments") != null:
+			data.attachments = []
+			for attachment in dict["attachments"]:
+				data.attachments.push_back(DiscordAttachment.decode(attachment))
+		if dict.get("reactions") != null:
+			data.reactions = []
+			for reaction in dict["reactions"]:
+				data.reactions.push_back(DiscordReaction.decode(reaction))
+		if dict.get("activity") != null:
+			data.activity = DiscordMessageActivity.decode(dict["activity"])
+		if dict.get("application") != null:
+			data.application = DiscordMessageApplication.decode(dict["application"])
+		if dict.get("message_reference") != null:
+			data.message_reference = DiscordMessageReference.decode(dict["message_reference"])
+		if dict.get("referenced_message") != null:
+			data.referenced_message = DiscordMessage.decode(dict["referenced_message"])
+		return data
+class DiscordMessageActivity:
+	## Type
+	var type: int
+	## Party ID (Nullable)
+	var party_id: String
+	static func decode(dict: Dictionary) -> DiscordMessageActivity:
+		var data := DiscordMessageActivity.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+class DiscordMessageApplication:
+	## ID
+	var id: String
+	## Cover image (Nullable)
+	var cover_image: String
+	## Description
+	var description: String
+	## Icon (Nullable)
+	var icon: String
+	## Name
+	var name: String
+	static func decode(dict: Dictionary) -> DiscordMessageApplication:
+		var data := DiscordMessageApplication.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+class DiscordMessageReference:
+	## Message ID (Nullable)
+	var message_id: String
+	## Channel ID (Nullable)
+	var channel_id: String
+	## Guild ID (Nullable)
+	var guild_id: String
+	static func decode(dict: Dictionary) -> DiscordMessageReference:
+		var data := DiscordMessageReference.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#sku
+class DiscordSku:
+	## ID
+	var id: String
+	## Name
+	var name: String
+	## Type
+	var type: DiscordSkuType
+	## Price
+	var price: DiscordSkuPrice
+	## Application ID
+	var application_id: String
+	## Flags
+	var flags: int
+	## Release date (Nullable)
+	var release_date: String
+	static func decode(dict: Dictionary) -> DiscordSku:
+		var data := DiscordSku.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("type") != null:
+			data.type = int(dict["type"]) as DiscordSkuType
+		if dict.get("price") != null:
+			data.price = DiscordSkuPrice.decode(dict["price"])
+		return data
+class DiscordSkuPrice:
+	var amount: float
+	var currency: String
+	static func decode(dict: Dictionary) -> DiscordSkuPrice:
+		var data := DiscordSkuPrice.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#entitlement
+class DiscordEntitlement:
+	## ID
+	var id: String
+	## SKU ID
+	var sku_id: String
+	## Application ID
+	var application_id: String
+	## User ID
+	var user_id: String
+	## Gift code flags
+	var gift_code_flags: int
+	## Type (String or int)
+	var type: Variant
+	## Gifter user ID (Nullable)
+	var gifter_user_id: String
+	## Branches (Nullable)
+	var branches: Array[String]
+	## Starts at (Nullable)
+	var starts_at: String
+	## Ends at (Nullable)
+	var ends_at: String	
+	## Parent ID (Nullable)
+	var parent_id: String
+	## Consumed (Nullable)
+	var consumed: bool
+	## Deleted (Nullable)
+	var deleted: bool
+	## Gift code batch ID (Nullable)
+	var gift_code_batch_id: String
+	static func decode(dict: Dictionary) -> DiscordEntitlement:
+		var data := DiscordEntitlement.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+#endregion
+
+
+#region Command response types (https://discord.com/developers/docs/developer-tools/embedded-app-sdk#sdk-commands)
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#authenticateresponse
+class CommandAuthenticateResponse:
+	## Access token
+	var access_token: String
+	## User
+	var user: DiscordUser
+	## Scopes
+	var scopes: Array[String] = []
+	## Expires
+	var expires: String
+	## Application
+	var application: DiscordApplication
+	static func decode(dict: Dictionary) -> CommandAuthenticateResponse:
+		var data := CommandAuthenticateResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("user") != null:
+			data.user = DiscordUser.decode(data["user"])
+		if dict.get("application") != null:
+			data.application = DiscordApplication.decode(data["application"])
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#authorizeresponse
+class CommandAuthorizeResponse:
+	## Authorization code
+	var code: String
+	static func decode(dict: Dictionary) -> CommandAuthorizeResponse:
+		var data := CommandAuthorizeResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#encouragehardwareaccelerationresponse
+class CommandEncourageHardwareAccelerationResponse:
+	var enabled: bool
+	static func decode(dict: Dictionary) -> CommandEncourageHardwareAccelerationResponse:
+		var data := CommandEncourageHardwareAccelerationResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getchannelpermissionsresponse
+class CommandGetChannelPermissionsResponse:
+	## Permissions (BigInt string)
+	var permissions: String
+	static func decode(dict: Dictionary) -> CommandGetChannelPermissionsResponse:
+		var data := CommandGetChannelPermissionsResponse.new()
+		data.permissions = str(dict["permissions"])
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getinstanceconnectedparticipantsresponse
+class CommandGetInstanceConnectedParticipantsResponse:
+	var participants: Array[DiscordUser]
+	static func decode(dict: Dictionary) -> CommandGetInstanceConnectedParticipantsResponse:
+		var data := CommandGetInstanceConnectedParticipantsResponse.new()
+		if dict.get("participants") != null:
+			data.participants = []
+			for participant in dict["participants"]:
+				data.participants.push_back(DiscordUser.decode(participant))
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getplatformbehaviorsresponse
+class CommandGetPlatformBehaviorsResponse:
+	## IOS keyboard resizes view 
+	var ios_keyboard_resizes_view: bool
+	static func decode(dict: Dictionary) -> CommandGetPlatformBehaviorsResponse:
+		var data := CommandGetPlatformBehaviorsResponse.new()
+		data.ios_keyboard_resizes_view = dict["iosKeyboardResizesView"]
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getrelationshipsresponse
+class CommandGetRelationshipsResponse:
+	var relationships: Array[DiscordRelationship]
+	static func decode(dict: Dictionary) -> CommandGetRelationshipsResponse:
+		var data := CommandGetRelationshipsResponse.new()
+		if dict.get("relationships") != null:
+			data.relationships = []
+			for relationship in dict["relationships"]:
+				data.relationships.push_back(DiscordRelationship.decode(relationship))
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getskusresponse
+class CommandGetSkusResponse:
+	var skus: Array[DiscordSku]
+	static func decode(dict: Dictionary) -> CommandGetSkusResponse:
+		var data := CommandGetSkusResponse.new()
+		if dict.get("skus") != null:
+			data.skus = []
+			for sku in dict["skus"]:
+				data.skus.push_back(DiscordSku.decode(sku))
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#initiateimageuploadresponse
+class CommandInitiateImageUploadResponse:
+	## Image URL
+	var image_url: String
+	static func decode(dict: Dictionary) -> CommandInitiateImageUploadResponse:
+		var data := CommandInitiateImageUploadResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#openexternallinkresponse
+class CommandOpenExternalLinkResponse:
+	## Opened (Nullable)
+	var opened: bool
+	static func decode(dict: Dictionary) -> CommandOpenExternalLinkResponse:
+		var data := CommandOpenExternalLinkResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#sharelinkresponse
+class CommandShareLinkResponse:
+	## Success
+	var success: bool
+	static func decode(dict: Dictionary) -> CommandShareLinkResponse:
+		var data := CommandShareLinkResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#usersettingsgetlocaleresponse
+class CommandUserSettingsGetLocaleResponse:
+	## Locale
+	var locale: String
+	static func decode(dict: Dictionary) -> CommandUserSettingsGetLocaleResponse:
+		var data := CommandUserSettingsGetLocaleResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#setconfigresponse
+class CommandSetConfigResponse:
+	## Use interactive PIP
+	var use_interactive_pip: bool
+	static func decode(dict: Dictionary) -> CommandSetConfigResponse:
+		var data := CommandSetConfigResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getchannelresponse
+class CommandGetChannelResponse:
+	## ID
+	var id: String
+	## Channel type
+	var type: DiscordChannelTypes
+	## Guild ID (Nullable)
+	var guild_id: String
+	## Name (Nullable)
+	var name: String
+	## Topic (Nullable)
+	var topic: String
+	## Bitrate (Nullable)
+	var bitrate: int
+	## User limit (Nullable)
+	var user_limit: int
+	## Position (Nullable)
+	var position: int
+	## Voice states
+	var voice_states: Array[DiscordUserVoiceState]
+	## Messages
+	var messages: Array[DiscordMessage]
+	static func decode(dict: Dictionary) -> CommandGetChannelResponse:
+		var data := CommandGetChannelResponse.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("voice_states") != null:
+			data.voice_states = []
+			for state in dict["voice_states"]:
+				data.voice_states.push_back(DiscordUserVoiceState.decode(state))
+		if dict.get("messages") != null:
+			data.messages = []
+			for message in dict["messages"]:
+				data.messages.push_back(DiscordMessage.decode(message))
+		return data
+
+## https://discord.com/developers/docs/developer-tools/embedded-app-sdk#getentitlementsresponse
+class CommandGetEntitlements:
+	var entitlements: Array[DiscordEntitlement]
+	static func decode(dict: Dictionary) -> CommandGetEntitlements:
+		var data := CommandGetEntitlements.new()
+		if dict.get("entitlements") != null:
+			data.entitlements = []
+			for entitlement in dict["entitlements"]:
+				data.entitlements.push_back(DiscordEntitlement.decode(entitlement))
 		return data
 #endregion
 
@@ -291,7 +855,6 @@ static func _decode_simple(dict: Dictionary, target: Object) -> void:
 		return
 	for key in dict.keys():
 		var value = dict[key]
-		var gotten = target.get(key)
 		target.set(key, value)
 
 
@@ -531,8 +1094,8 @@ func _wait_for_nonce(nonce: String):
 			break
 	return packet["data"]
 
-func command_authorize(response_type: String, scopes: Array, state: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_authorize(response_type: String, scopes: Array, state: String) -> CommandAuthorizeResponse:
+	var nonce := _gen_nonce()
 	sendCommand("AUTHORIZE", {
 		"client_id": client_id,
 		"prompt": "none",
@@ -542,122 +1105,115 @@ func command_authorize(response_type: String, scopes: Array, state: String) -> D
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandAuthorizeResponse.decode(packet)
 
-func command_authenticate(access_token: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_authenticate(access_token: String) -> CommandAuthenticateResponse:
+	var nonce := _gen_nonce()
 	sendCommand("AUTHENTICATE", {
 		"access_token": access_token
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandAuthenticateResponse.decode(packet)
 
-func command_capture_log(level: String, message: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_capture_log(level: String, message: String) -> void:
+	var nonce := _gen_nonce()
 	sendCommand("CAPTURE_LOG", {
 		"level": level,
 		"message": message
 	}, nonce)
+	await _wait_for_nonce(nonce)
 
-	var packet = await _wait_for_nonce(nonce)
-	return packet
-
-func command_encourage_hardware_acceleration() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_encourage_hardware_acceleration() -> CommandEncourageHardwareAccelerationResponse:
+	var nonce := _gen_nonce()
 	sendCommand("ENCOURAGE_HW_ACCELERATION", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandEncourageHardwareAccelerationResponse.decode(packet)
 
-func command_get_channel(id: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_get_channel(id: String) -> CommandGetChannelResponse:
+	var nonce := _gen_nonce()
 	sendCommand("GET_CHANNEL", {
 		"channel_id": id
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandGetChannelResponse.decode(packet)
 
 
-func command_get_channel_permissions() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_get_channel_permissions() -> CommandGetChannelPermissionsResponse:
+	var nonce := _gen_nonce()
 	sendCommand("GET_CHANNEL_PERMISSIONS", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandGetChannelPermissionsResponse.decode(packet)
 
 
-func command_get_entitlements_embedded() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_get_entitlements_embedded() -> CommandGetEntitlements:
+	var nonce := _gen_nonce()
 	sendCommand("GET_ENTITLEMENTS_EMBEDDED", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandGetEntitlements.decode(packet)
 
 
-func command_get_instance_connected_participants() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_get_instance_connected_participants() -> CommandGetInstanceConnectedParticipantsResponse:
+	var nonce := _gen_nonce()
 	sendCommand("GET_ACTIVITY_INSTANCE_CONNECTED_PARTICIPANTS", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandGetInstanceConnectedParticipantsResponse.decode(packet)
 
 
-func command_get_platform_behaviors() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_get_platform_behaviors() -> CommandGetPlatformBehaviorsResponse:
+	var nonce := _gen_nonce()
 	sendCommand("GET_PLATFORM_BEHAVIORS", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandGetPlatformBehaviorsResponse.decode(packet)
 
 
-func command_get_skus() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_get_skus() -> CommandGetSkusResponse:
+	var nonce := _gen_nonce()
 	sendCommand("GET_SKUS_EMBEDDED", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandGetSkusResponse.decode(packet)
 
 
-func command_initiate_image_upload() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_initiate_image_upload() -> CommandInitiateImageUploadResponse:
+	var nonce := _gen_nonce()
 	sendCommand("INITIATE_IMAGE_UPLOAD", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandInitiateImageUploadResponse.decode(packet)
 
 
-func command_open_external_link(url: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_open_external_link(url: String) -> CommandOpenExternalLinkResponse:
+	var nonce := _gen_nonce()
 	sendCommand("OPEN_EXTERNAL_LINK", {
 		"url": url
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandOpenExternalLinkResponse.decode(packet)
 
 
-func command_open_invite_dialog() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_open_invite_dialog() -> void:
+	var nonce := _gen_nonce()
 	sendCommand("OPEN_INVITE_DIALOG", {}, nonce)
-
-	var packet = await _wait_for_nonce(nonce)
-	return packet
+	await _wait_for_nonce(nonce)
 
 
-func command_open_share_moment_dialog(media_url: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_open_share_moment_dialog(media_url: String) -> void:
+	var nonce := _gen_nonce()
 	sendCommand("OPEN_SHARE_MOMENT_DIALOG", {
 		"mediaUrl": media_url
 	}, nonce)
+	await _wait_for_nonce(nonce)
 
-	var packet = await _wait_for_nonce(nonce)
-	return packet
-
-
-func command_set_activity(state: String, details: String, timestamps: Dictionary = {}, assets: Dictionary = {}, party: Dictionary = {}, secrets: Dictionary = {}, instance: bool = false) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_set_activity(state: String, details: String, timestamps: Dictionary = {}, assets: Dictionary = {}, party: Dictionary = {}, secrets: Dictionary = {}, instance: bool = false) -> DiscordActivity:
+	var nonce := _gen_nonce()
 	sendCommand("SET_ACTIVITY", {
 		"activity": {
 			"state": state,
@@ -671,56 +1227,52 @@ func command_set_activity(state: String, details: String, timestamps: Dictionary
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return DiscordActivity.decode(packet)
 
 
-func command_set_config(use_interactive_pip: bool) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_set_config(use_interactive_pip: bool) -> CommandSetConfigResponse:
+	var nonce := _gen_nonce()
 	sendCommand("SET_CONFIG", {
 		"use_interactive_pip": use_interactive_pip
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandSetConfigResponse.decode(packet)
 
 
-
-# UNHANDLED: -1
-# PORTRAIT: 0
-# LANDSCAPE: 1
-func command_set_orientation_lock_state(lock_state: int, pip_lock_state: int, grid_lock_state: int) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_set_orientation_lock_state(lock_state: DiscordOrientationLockStateType, pip_lock_state: DiscordOrientationLockStateType, grid_lock_state: DiscordOrientationLockStateType) -> void:
+	var nonce := _gen_nonce()
 	sendCommand("SET_ORIENTATION_LOCK_STATE", {
 		"lock_state": lock_state,
 		"pip_lock_state": pip_lock_state,
 		"grid_lock_state": grid_lock_state
 	}, nonce)
+	await _wait_for_nonce(nonce)
 
-	var packet = await _wait_for_nonce(nonce)
-	return packet
-
-
-func command_start_purchase(sku_id: String, pid: int) -> Dictionary:
-	var nonce = _gen_nonce()
+## Returns either null or [DiscordEntitlement]
+func command_start_purchase(sku_id: String, pid: int) -> DiscordEntitlement:
+	var nonce := _gen_nonce()
 	sendCommand("START_PURCHASE", {
 		"sku_id": sku_id,
 		"pid": pid
 	}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	if packet == null:
+		return null
+	return DiscordEntitlement.decode(packet)
 
 
-func command_user_settings_get_locale() -> Dictionary:
-	var nonce = _gen_nonce()
+func command_user_settings_get_locale() -> CommandUserSettingsGetLocaleResponse:
+	var nonce := _gen_nonce()
 	sendCommand("USER_SETTINGS_GET_LOCALE", {}, nonce)
 
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandUserSettingsGetLocaleResponse.decode(packet)
 
 
-func command_share_link(message: String, referrer_id: String, custom_id: String) -> Dictionary:
-	var nonce = _gen_nonce()
+func command_share_link(message: String, referrer_id: String, custom_id: String) -> CommandShareLinkResponse:
+	var nonce := _gen_nonce()
 	sendCommand("SHARE_LINK", {
 		"referrer_id": referrer_id,
 		"custom_id": custom_id,
@@ -728,4 +1280,4 @@ func command_share_link(message: String, referrer_id: String, custom_id: String)
 	}, nonce)
 	
 	var packet = await _wait_for_nonce(nonce)
-	return packet
+	return CommandShareLinkResponse.decode(packet)

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -421,7 +421,7 @@ func init(client_id_: String):
 	source_origin = JavaScriptBridge.eval("!!document.referrer ? document.referrer : '*'")
 	handshake()
 
-func sendMessage(opcode: Variant, body: Dictionary):
+func sendMessage(opcode: int, body: Dictionary):
 	if (not in_js):
 		print("Not in a JavaScript environment. Ignoring call to sendMessage()")
 		return

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -435,7 +435,7 @@ func sendMessage(opcode: int, body: Dictionary):
 	JavaScriptBridge.eval("window.source.postMessage(" + JSON.stringify(data).replace("'", "\\'") + ", '*')", false)
 	#source.postMessage(data, "*")
 
-func sendCommand(cmd: Variant, args: Dictionary, nonce: String):
+func sendCommand(cmd: String, args: Dictionary, nonce: String):
 	if (not in_js):
 		print("Not in a JavaScript environment. Ignoring call to sendCommand()")
 		return

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -1,42 +1,315 @@
 class_name DiscordSDK
 extends Node
 
+
+#region Signals
 signal packet_received
 signal _command_response_received
 
-signal dispatch_ready
-signal dispatch_error
-signal dispatch_voice_state_update
-signal dispatch_speaking_start
-signal dispatch_speaking_stop
-signal dispatch_activity_layout_mode_update
-signal dispatch_orientation_update
-signal dispatch_current_user_update
-signal dispatch_thermal_state_update
-signal dispatch_activity_instance_participants_update
-signal dispatch_entitlement_create
-signal dispatch_current_guild_member_update
-signal dispatch_any
+## Receives a [DiscordSDK.ReadyEventData]
+signal dispatch_ready(data: ReadyEventData)
 
-var callback_func : JavaScriptObject = JavaScriptBridge.create_callback(_handle_message);
-var frame_id : String
-var instance_id : String
-var platform : String
-var channel_id : String
-var client_id : String
-var guild_id : String
-var user_id : String
-var custom_id : String
-var referrer_id : String
+## Receives a [DiscordSDK.ErrorEventData]
+signal dispatch_error(data: ErrorEventData)
 
-var source : JavaScriptObject
-var source_origin : String
+## Receives a [DiscordSDK.VoiceStateUpdateData]
+signal dispatch_voice_state_update(data: VoiceStateUpdateData)
 
-var is_ready = false
-var subscribed = false
-var in_js = false
+## Receives a [DiscordSDK.SpeakingEventData]
+signal dispatch_speaking_start(data: SpeakingEventData)
 
-var _events = ["VOICE_STATE_UPDATE", "SPEAKING_START", "SPEAKING_STOP",
+## Receives a [DiscordSDK.SpeakingEventData]
+signal dispatch_speaking_stop(data: SpeakingEventData)
+
+## Receives a [DiscordSDK.ActivityLayoutModeUpdateData]
+signal dispatch_activity_layout_mode_update(data: ActivityLayoutModeUpdateData)
+
+## Receives a [DiscordSDK.OrientationUpdateData]
+signal dispatch_orientation_update(data: OrientationUpdateData)
+
+## Receives a [DiscordSDK.CurrentUserUpdateData]
+signal dispatch_current_user_update(data: CurrentUserUpdateData)
+
+## Receives a [DiscordSDK.ThermalStateUpdateData]
+signal dispatch_thermal_state_update(data: ThermalStateUpdateData)
+
+## Receives a [DiscordSDK.ParticipantsUpdateData]
+signal dispatch_activity_instance_participants_update(data: ParticipantsUpdateData)
+
+## Receives a [DiscordSDK.CurrentUserUpdateData]
+signal dispatch_current_guild_member_update(data: CurrentUserUpdateData)
+
+signal dispatch_entitlement_create(data: Dictionary)
+signal dispatch_any(data: Dictionary)
+#endregion
+
+
+#region Data types (https://discord.com/developers/docs/developer-tools/embedded-app-sdk)
+#       Postfix these with EventData", or "UpdateData" for update events.
+#       Call _decode_simple to automatically decode primitive fields
+#       Manually call decode on a class to convert a dictionary to it
+## Event data for [signal dispatch_ready]
+class ReadyEventData:
+	var v: int
+	var config: ReadyEventDataConfig
+	static func decode(dict: Dictionary) -> ReadyEventData:
+		var data := ReadyEventData.new()
+		DiscordSDK._decode_simple(dict, data)
+		data.config = ReadyEventDataConfig.decode(dict["config"])
+		return data
+class ReadyEventDataConfig:
+	var cdn_host: String
+	var api_endpoint: String
+	var environment: String
+	static func decode(dict: Dictionary) -> ReadyEventDataConfig:
+		var data := ReadyEventDataConfig.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## Event data for [signal dispatch_error]
+class ErrorEventData:
+	var code: int
+	var message: String
+	static func decode(dict: Dictionary) -> ErrorEventData:
+		var data := ErrorEventData.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## Event data for [signal dispatch_voice_state_update]
+class VoiceStateUpdateData:
+	var voice_state: DiscordVoiceState
+	var user: DiscordSimpleUser
+	var nick: String
+	var volume: int
+	var mute: bool
+	var pan: DiscordAudioPan
+	static func decode(dict: Dictionary) -> VoiceStateUpdateData:
+		var data := VoiceStateUpdateData.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("voice_state") != null:
+			data.voice_state = DiscordVoiceState.decode(dict["voice_state"])
+		if dict.get("user") != null:
+			data.user = DiscordSimpleUser.decode(dict["user"])
+		if dict.get("pan") != null:
+			data.pan = DiscordAudioPan.decode(dict["pan"])
+		return data
+
+## Event data for [signal dispatch_speaking_start] and [signal dispatch_speaking_stop]
+class SpeakingEventData:
+	var channel_id: String
+	var user_id: String
+	static func decode(dict: Dictionary) -> SpeakingEventData:
+		var data := SpeakingEventData.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## Event data for [signal dispatch_activity_layout_mode_update]
+class ActivityLayoutModeUpdateData:
+	var layout_mode: int
+	static func decode(dict: Dictionary) -> ActivityLayoutModeUpdateData:
+		var data := ActivityLayoutModeUpdateData.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## Event data for [signal dispatch_activity_layout_mode_update]
+class OrientationUpdateData:
+	var screen_orientation: int
+	static func decode(dict: Dictionary) -> OrientationUpdateData:
+		var data := OrientationUpdateData.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## Event data for [signal dispatch_current_user_update]
+class CurrentUserUpdateData:
+	var user_id: String
+	var nick: String
+	var guild_id: String
+	var avatar: String
+	var avatar_decoration_data: DiscordAvatarDecorationData
+	var color_string: String
+	static func decode(dict: Dictionary) -> CurrentUserUpdateData:
+		var data := CurrentUserUpdateData.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("avatar_decoration_data") != null:
+			data.avatar_decoration_data = DiscordAvatarDecorationData.decode(dict["avatar_decoration_data"])
+		return data
+
+## Event data for [signal dispatch_thermal_state_update]
+class ThermalStateUpdateData:
+	var thermal_state: int
+	static func decode(dict: Dictionary) -> ThermalStateUpdateData:
+		var data := ThermalStateUpdateData.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+## Event data for [signal dispatch_activity_instance_participants_update]
+class ParticipantsUpdateData:
+	var participants: Array[DiscordUser] = []
+	static func decode(dict: Dictionary) -> ParticipantsUpdateData:
+		var data := ParticipantsUpdateData.new()
+		if dict.get("participants") != null:
+			for participant in dict["participants"]:
+				data.participants.push_back(DiscordUser.decode(participant))
+		return data
+#endregion
+
+
+#region Custom SDK types, only used for this SDK
+class DiscordVoiceState:
+	var mute: bool
+	var deaf: bool
+	var self_mute: bool
+	var self_deaf: bool
+	var suppress: bool
+	static func decode(dict: Dictionary) -> DiscordVoiceState:
+		var data := DiscordVoiceState.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+class DiscordAudioPan:
+	var left: float
+	var right: float
+	static func decode(dict: Dictionary) -> DiscordAudioPan:
+		var data := DiscordAudioPan.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+#endregion
+
+
+#region SDK interface types (https://discord.com/developers/docs/developer-tools/embedded-app-sdk#sdk-interfaces)
+#       Prefix them with "Discord" in order to not clash with outside types.
+class DiscordActivity:
+	## The name of the activity
+	var name: String
+	## The type of the activity
+	var type: int
+	## The url of the activity (Nullable)
+	var url: String
+	## Activity creation time (Nullable)
+	var created_at: int
+	## Timestamps (Nullable)
+	var timestamps: DiscordTimestamp = null
+	## Application ID (Nullable)
+	var application_id: String
+	## Details (Nullable)
+	var details: String
+	## State (Nullable)
+	var state: String
+	## Emoji (Nullable)
+	var emoji: DiscordEmoji
+	
+	static func decode(dict: Dictionary) -> DiscordAudioPan:
+		var data := DiscordAudioPan.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("timestamps") != null:
+			data.timestamps = DiscordTimestamp.decode(dict["timestamps"])
+		if dict.get("emoji") != null:
+			data.emoji = DiscordEmoji.decode(dict["emoji"])
+		return data
+
+class DiscordEmoji:
+	## Emoji ID
+	var id: String
+	## Name (Nullable)
+	var name: String
+	## Roles (Nullable)
+	var roles: Array[String]
+	## User (Nullable)
+	var user: DiscordUser
+	## Require colons (Nullable)
+	var require_colons: bool
+	## Managed (Nullable)
+	var managed: bool
+	## Animated (Nullable)
+	var animated: bool
+	## Available (Nullable)
+	var available: bool
+	static func decode(dict: Dictionary) -> DiscordEmoji:
+		var data := DiscordEmoji.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("user") != null:
+			data.user = DiscordUser.decode(dict["user"])
+		return data
+
+class DiscordTimestamp:
+	## Start time (Nullable)
+	var start: int
+	## End time (Nullable)
+	var end: int
+	static func decode(dict: Dictionary) -> DiscordTimestamp:
+		var data := DiscordTimestamp.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+
+class DiscordUser extends DiscordSimpleUser:
+	## Global name (Nullable)
+	var global_name: String
+	## Avatar decoration data (Nullable)
+	var avatar_decoration_data: DiscordAvatarDecorationData
+	## Flags (Nullable)
+	var flags: int
+	## Premium type (Nullable)
+	var premium_type: int
+	static func decode(dict: Dictionary) -> DiscordUser:
+		var data := DiscordUser.new()
+		DiscordSDK._decode_simple(dict, data)
+		if dict.get("avatar_decoration_data") != null:
+			data.avatar_decoration_data = DiscordAvatarDecorationData.decode(dict["avatar_decoration_data"])
+		return data
+class DiscordSimpleUser:
+	## User ID
+	var id: String
+	## Username
+	var username: String
+	## Username discriminator
+	var discriminator: String
+	## Avatar hash (Nullable)
+	var avatar: String
+	## Whenever the user is a bot
+	var bot: bool
+	static func decode(dict: Dictionary) -> DiscordSimpleUser:
+		var data := DiscordSimpleUser.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+class DiscordAvatarDecorationData:
+	## Asset
+	var asset: String
+	## (Nullable)
+	var sku_id: String
+	static func decode(dict: Dictionary) -> DiscordAvatarDecorationData:
+		var data := DiscordAvatarDecorationData.new()
+		DiscordSDK._decode_simple(dict, data)
+		return data
+#endregion
+
+## Automatically decodes anything that isn't a class
+static func _decode_simple(dict: Dictionary, target: Object) -> void:
+	if dict == null:
+		return
+	for key in dict.keys():
+		var value = dict[key]
+		var gotten = target.get(key)
+		target.set(key, value)
+
+
+var callback_func := JavaScriptBridge.create_callback(_handle_message);
+var frame_id: String
+var instance_id: String
+var platform: String
+var channel_id: String
+var client_id: String
+var guild_id: String
+var user_id: String
+var custom_id: String
+var referrer_id: String
+
+var source: JavaScriptObject
+var source_origin: String
+
+var is_ready := false
+var subscribed := false
+var in_js := false
+
+var _events := ["VOICE_STATE_UPDATE", "SPEAKING_START", "SPEAKING_STOP",
 	"ACTIVITY_LAYOUT_MODE_UPDATE", "ORIENTATION_UPDATE", "CURRENT_USER_UPDATE",
 	"THERMAL_STATE_UPDATE", "ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE", "ENTITLEMENT_CREATE",
 	"CURRENT_GUILD_MEMBER_UPDATE"]
@@ -44,7 +317,7 @@ var _events = ["VOICE_STATE_UPDATE", "SPEAKING_START", "SPEAKING_STOP",
 func _handle_message(event):
 	var data_json = JavaScriptBridge.get_interface("JSON").stringify(event[0].data[1])
 	var data = JSON.parse_string(data_json)
-	
+
 	# Add to the packet response buffer so we can access them from functions later on
 	if (event[0].data[0] == 1): # Opcode.FRAME
 		if (data["cmd"] == "DISPATCH"):
@@ -62,30 +335,41 @@ func _handle_dispatch(data):
 	match event:
 		"READY":
 			is_ready = true
-			dispatch_ready.emit(data["data"])
+			var event_data := ReadyEventData.decode(data["data"])
+			dispatch_ready.emit(event_data)
 		"ERROR":
-			dispatch_error.emit(data["data"])
+			var event_data := ErrorEventData.decode(data["data"])
+			dispatch_error.emit(event_data)
 		"VOICE_STATE_UPDATE":
-			dispatch_voice_state_update.emit(data["data"])
+			var event_data := VoiceStateUpdateData.decode(data["data"])
+			dispatch_voice_state_update.emit(event_data)
 		"SPEAKING_START":
-			dispatch_speaking_start.emit(data["data"])
+			var event_data := SpeakingEventData.decode(data["data"])
+			dispatch_speaking_start.emit(event_data)
 		"SPEAKING_STOP":
-			dispatch_speaking_stop.emit(data["data"])
+			var event_data := SpeakingEventData.decode(data["data"])
+			dispatch_speaking_stop.emit(event_data)
 		"ACTIVITY_LAYOUT_MODE_UPDATE":
-			dispatch_activity_layout_mode_update.emit(data["data"])
+			var event_data := ActivityLayoutModeUpdateData.decode(data["data"])
+			dispatch_activity_layout_mode_update.emit(event_data)
 		"ORIENTATION_UPDATE":
-			dispatch_orientation_update.emit(data["data"])
+			var event_data := OrientationUpdateData.decode(data["data"])
+			dispatch_orientation_update.emit(event_data)
 		"CURRENT_USER_UPDATE":
 			user_id = data["data"]["id"]
-			dispatch_current_user_update.emit(data["data"])
+			var event_data := CurrentUserUpdateData.decode(data["data"])
+			dispatch_current_user_update.emit(event_data)
 		"THERMAL_STATE_UPDATE":
-			dispatch_thermal_state_update.emit(data["data"])
+			var event_data := ThermalStateUpdateData.decode(data["data"])
+			dispatch_thermal_state_update.emit(event_data)
 		"ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE":
-			dispatch_activity_instance_participants_update.emit(data["data"])
+			var event_data := ParticipantsUpdateData.decode(data["data"])
+			dispatch_activity_instance_participants_update.emit(event_data)
 		"ENTITLEMENT_CREATE":
-			dispatch_entitlement_create.emit(data["data"])
+			dispatch_entitlement_create.emit(data["data"] as Dictionary)
 		"CURRENT_GUILD_MEMBER_UPDATE":
-			dispatch_current_guild_member_update.emit(data["data"])
+			var event_data := CurrentUserUpdateData.decode(data["data"])
+			dispatch_current_guild_member_update.emit(event_data)
 		_:
 			print("_handle_dispatch: Warning! Unknown event: " + str(event)) # convert to string just to be sure
 
@@ -102,19 +386,19 @@ func init(client_id_: String):
 	if (not in_js):
 		print("Not in a JavaScript environment. Ignoring call to init()")
 		return
-	var query_parts = str(JavaScriptBridge.eval("window.location.search")).trim_prefix("?").split("&", false)
-	var query_map = {}
+	var query_parts := str(JavaScriptBridge.eval("window.location.search")).trim_prefix("?").split("&", false)
+	var query_map := {}
 	for part in query_parts:
-		var parts = part.split("=")
+		var parts := part.split("=")
 		query_map[parts[0]] = parts[1]
-	
+
 	if (!query_map.has("frame_id")):
-		push_error("frameId query variable is not set!")	
+		push_error("frameId query variable is not set!")
 	if (!query_map.has("instance_id")):
 		push_error("instanceId query variable is not set!")
 	if (!query_map.has("platform")):
 		push_error("platform query variable is not set!")
-	
+
 	frame_id = query_map["frame_id"]
 	instance_id = query_map["instance_id"]
 	platform = query_map["platform"]
@@ -133,11 +417,11 @@ func init(client_id_: String):
 	if (source == null):
 		source = JavaScriptBridge.get_interface("window").parent
 	JavaScriptBridge.eval("window.source = window.parent.opener ?? window.parent", true)
-	
+
 	source_origin = JavaScriptBridge.eval("!!document.referrer ? document.referrer : '*'")
 	handshake()
 
-func sendMessage(opcode, body):
+func sendMessage(opcode: Variant, body: Dictionary):
 	if (not in_js):
 		print("Not in a JavaScript environment. Ignoring call to sendMessage()")
 		return
@@ -145,13 +429,13 @@ func sendMessage(opcode, body):
 		opcode,
 		body
 	]
-	# note about this, source.postMessage doesn't work, because `data` somehow 
+	# note about this, source.postMessage doesn't work, because `data` somehow
 	# turns into `undefined` somewhere. not sure how to fix, but this works
 	# for now.
 	JavaScriptBridge.eval("window.source.postMessage(" + JSON.stringify(data).replace("'", "\\'") + ", '*')", false)
 	#source.postMessage(data, "*")
 
-func sendCommand(cmd, args, nonce):
+func sendCommand(cmd: Variant, args: Dictionary, nonce: String):
 	if (not in_js):
 		print("Not in a JavaScript environment. Ignoring call to sendCommand()")
 		return
@@ -160,8 +444,8 @@ func sendCommand(cmd, args, nonce):
 		"args": args,
 		"nonce": nonce
 	})
-	
-func _gen_nonce():
+
+func _gen_nonce() -> String:
 	var chars = "0123456789abcdef"
 	var output_string := ""
 
@@ -219,7 +503,7 @@ func close(code: int, message: String):
 		"nonce": _gen_nonce()
 	})
 
-func _wait_for_nonce(nonce):
+func _wait_for_nonce(nonce: String):
 	var noMatches = true
 	var packet = null
 	while noMatches:
@@ -231,7 +515,7 @@ func _wait_for_nonce(nonce):
 			break
 	return packet["data"]
 
-func command_authorize(response_type: String, scopes: Array, state: String):
+func command_authorize(response_type: String, scopes: Array, state: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("AUTHORIZE", {
 		"client_id": client_id,
@@ -240,124 +524,123 @@ func command_authorize(response_type: String, scopes: Array, state: String):
 		"scope": scopes,
 		"state": state
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
-func command_authenticate(access_token: String):
+func command_authenticate(access_token: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("AUTHENTICATE", {
 		"access_token": access_token
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
-func command_capture_log(level: String, message: String):
+func command_capture_log(level: String, message: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("CAPTURE_LOG", {
 		"level": level,
 		"message": message
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
-func command_encourage_hardware_acceleration():
+func command_encourage_hardware_acceleration() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("ENCOURAGE_HW_ACCELERATION", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
-
-func command_get_channel(id: String):
+func command_get_channel(id: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("GET_CHANNEL", {
 		"channel_id": id
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_get_channel_permissions():
+func command_get_channel_permissions() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("GET_CHANNEL_PERMISSIONS", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_get_entitlements_embedded():
+func command_get_entitlements_embedded() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("GET_ENTITLEMENTS_EMBEDDED", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_get_instance_connected_participants():
+func command_get_instance_connected_participants() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("GET_ACTIVITY_INSTANCE_CONNECTED_PARTICIPANTS", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_get_platform_behaviors():
+func command_get_platform_behaviors() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("GET_PLATFORM_BEHAVIORS", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_get_skus():
+func command_get_skus() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("GET_SKUS_EMBEDDED", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_initiate_image_upload():
+func command_initiate_image_upload() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("INITIATE_IMAGE_UPLOAD", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_open_external_link(url: String):
+func command_open_external_link(url: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("OPEN_EXTERNAL_LINK", {
 		"url": url
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_open_invite_dialog():
+func command_open_invite_dialog() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("OPEN_INVITE_DIALOG", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_open_share_moment_dialog(media_url: String):
+func command_open_share_moment_dialog(media_url: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("OPEN_SHARE_MOMENT_DIALOG", {
 		"mediaUrl": media_url
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_set_activity(state: String, details: String, timestamps: Dictionary = {}, assets: Dictionary = {}, party: Dictionary = {}, secrets: Dictionary = {}, instance: bool = false):
+func command_set_activity(state: String, details: String, timestamps: Dictionary = {}, assets: Dictionary = {}, party: Dictionary = {}, secrets: Dictionary = {}, instance: bool = false) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("SET_ACTIVITY", {
 		"activity": {
@@ -370,17 +653,17 @@ func command_set_activity(state: String, details: String, timestamps: Dictionary
 			"instance": instance
 		}
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_set_config(use_interactive_pip: bool):
+func command_set_config(use_interactive_pip: bool) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("SET_CONFIG", {
 		"use_interactive_pip": use_interactive_pip
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
@@ -389,38 +672,38 @@ func command_set_config(use_interactive_pip: bool):
 # UNHANDLED: -1
 # PORTRAIT: 0
 # LANDSCAPE: 1
-func command_set_orientation_lock_state(lock_state: int, pip_lock_state: int, grid_lock_state: int):
+func command_set_orientation_lock_state(lock_state: int, pip_lock_state: int, grid_lock_state: int) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("SET_ORIENTATION_LOCK_STATE", {
 		"lock_state": lock_state,
 		"pip_lock_state": pip_lock_state,
 		"grid_lock_state": grid_lock_state
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_start_purchase(sku_id: String, pid: int):
+func command_start_purchase(sku_id: String, pid: int) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("START_PURCHASE", {
 		"sku_id": sku_id,
 		"pid": pid
 	}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_user_settings_get_locale():
+func command_user_settings_get_locale() -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("USER_SETTINGS_GET_LOCALE", {}, nonce)
-	
+
 	var packet = await _wait_for_nonce(nonce)
 	return packet
 
 
-func command_share_link(message: String, referrer_id: String, custom_id: String):
+func command_share_link(message: String, referrer_id: String, custom_id: String) -> Dictionary:
 	var nonce = _gen_nonce()
 	sendCommand("SHARE_LINK", {
 		"referrer_id": referrer_id,

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd
@@ -39,8 +39,11 @@ signal dispatch_activity_instance_participants_update(data: ParticipantsUpdateDa
 ## Receives a [DiscordSDK.CurrentUserUpdateData]
 signal dispatch_current_guild_member_update(data: CurrentUserUpdateData)
 
+## Receives a [Dictionary]. This should be replaced by a proper type when its later added.
 signal dispatch_entitlement_create(data: Dictionary)
-signal dispatch_any(data: Dictionary)
+
+## Receives any event type, or a [Dictionary]
+signal dispatch_any(data: Object)
 #endregion
 
 
@@ -281,6 +284,7 @@ class DiscordAvatarDecorationData:
 		return data
 #endregion
 
+
 ## Automatically decodes anything that isn't a class
 static func _decode_simple(dict: Dictionary, target: Object) -> void:
 	if dict == null:
@@ -331,46 +335,58 @@ func _handle_message(event):
 
 func _handle_dispatch(data):
 	var event = data["evt"]
-	dispatch_any.emit(event, data["data"])
 	match event:
 		"READY":
 			is_ready = true
 			var event_data := ReadyEventData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_ready.emit(event_data)
 		"ERROR":
 			var event_data := ErrorEventData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_error.emit(event_data)
 		"VOICE_STATE_UPDATE":
 			var event_data := VoiceStateUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_voice_state_update.emit(event_data)
 		"SPEAKING_START":
 			var event_data := SpeakingEventData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_speaking_start.emit(event_data)
 		"SPEAKING_STOP":
 			var event_data := SpeakingEventData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_speaking_stop.emit(event_data)
 		"ACTIVITY_LAYOUT_MODE_UPDATE":
 			var event_data := ActivityLayoutModeUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_activity_layout_mode_update.emit(event_data)
 		"ORIENTATION_UPDATE":
 			var event_data := OrientationUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_orientation_update.emit(event_data)
 		"CURRENT_USER_UPDATE":
 			user_id = data["data"]["id"]
 			var event_data := CurrentUserUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_current_user_update.emit(event_data)
 		"THERMAL_STATE_UPDATE":
 			var event_data := ThermalStateUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_thermal_state_update.emit(event_data)
 		"ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE":
 			var event_data := ParticipantsUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_activity_instance_participants_update.emit(event_data)
 		"ENTITLEMENT_CREATE":
+			dispatch_any.emit(event, data["data"] as Dictionary)
 			dispatch_entitlement_create.emit(data["data"] as Dictionary)
 		"CURRENT_GUILD_MEMBER_UPDATE":
 			var event_data := CurrentUserUpdateData.decode(data["data"])
+			dispatch_any.emit(event, event_data)
 			dispatch_current_guild_member_update.emit(event_data)
 		_:
+			dispatch_any.emit(event, data["data"])
 			print("_handle_dispatch: Warning! Unknown event: " + str(event)) # convert to string just to be sure
 
 func _ready():

--- a/plugins/DiscordEmbeddedSDK/DiscordSDK.gd.uid
+++ b/plugins/DiscordEmbeddedSDK/DiscordSDK.gd.uid
@@ -1,0 +1,1 @@
+uid://dgiin8re2ojon

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="DiscordEmbeddedGodot"
 run/main_scene="res://playground/playground.tscn"
-config/features=PackedStringArray("4.3")
+config/features=PackedStringArray("4.4")
 config/icon="res://icon.png"
 
 [autoload]


### PR DESCRIPTION
Previously, there was no static typing whatsoever; No autocompletion for Discord SDK things, etc. I've managed to pull it off pretty easily, only to realize GDScript does not allow converting dictionaries to classes, and I've had to write a decoder to convert dictionaries into classes manually. This approach is far from perfect, and particularly suffers currently as there is no way to really inherit types if they have custom classes as values without completely copying over the decode function. To note as well is that the null checks inside of some of the decode functions happen for every property, regardless if it's nullable or not in the API, as there's no way as far as I can tell to check for those specific events/data structures.

I've tested the PR, and it works on my machine, but I'd recommend further testing for the PR before merging. With the way it currently is implemented, it will make the SDK a bit harder to maintain, but I wrecken static typing and safety is more important than maintainer convenience, and Discord doesn't update the embedded SDK frequently anymore anyway.

This approach also does have an upside however, as each field can now be decoded manually, you could implement checks for things like if the Discord API's output does not match what the classes expected. I would still look into finding another way to make this work if i were you, but I hope my class definitions and other static typing thingies help.